### PR TITLE
Handle list and non list publish_data

### DIFF
--- a/hooks/upload_version.py
+++ b/hooks/upload_version.py
@@ -226,7 +226,9 @@ class UploadVersionPlugin(HookBaseClass):
 
         if "sg_publish_data" in item.properties:
             publish_data = item.properties["sg_publish_data"]
-            version_data["published_files"] = [publish_data]
+            if not isinstance(publish_data, list):
+                publish_data = [publish_data]
+            version_data["published_files"] = publish_data
 
         if settings["Link Local File"].value:
             version_data["sg_path_to_movie"] = path


### PR DESCRIPTION
This lets you handle cases where you have more than one published file at once without breaking (think exporting data from your main scene, ie generating a fbx file from a maya scene).

If you want to track this file and link it to the version at the same time as the published_file, you need publish_data to actually be a list